### PR TITLE
Update makegrid.js

### DIFF
--- a/src/makegrid.js
+++ b/src/makegrid.js
@@ -81,7 +81,7 @@
     if (gridEl) {
         var content = gridEl.getAttribute('content');
         if (content) {
-            var reg = /([^=]+)=([\d\.\-]+)/g;
+            var reg = /,?([^=]+)=([\d\.\-]+)/g;
             var matched;
             var params = {};
             while (!!(matched = reg.exec(content))) {


### PR DESCRIPTION
对meta里content值正则有问题，导致匹配出来的结果params里的key前面会有个逗号
